### PR TITLE
Add uv instructions and pin deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+# Codex Metrics Dashboard
+
+This project provides a Streamlit dashboard for visualizing code metrics.
+
+## Virtual Environment Setup
+
+1. Ensure Python 3.9 or newer is installed.
+2. Install [`uv`](https://github.com/astral-sh/uv) if not already available:
+
+   ```bash
+   pip install uv
+   ```
+
+3. Create and activate a virtual environment:
+
+   ```bash
+   uv venv .venv
+   source .venv/bin/activate
+   ```
+
+4. Install dependencies with `uv pip`:
+
+   ```bash
+   uv pip install -r requirements.txt
+   ```
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+streamlit==1.46.0
+plotly==6.1.2


### PR DESCRIPTION
## Summary
- document using `uv` for managing the virtual environment
- pin Streamlit and Plotly versions in `requirements.txt`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6859865759f8832980013aa4392c13c3