### PR TITLE
Add CI workflow to run tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,24 @@
+name: Run tests
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install uv
+          uv pip install -r requirements.txt
+          uv pip install pytest
+      - name: Run tests
+        run: pytest -q


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run `pytest` on PRs and pushes to `master`
- use `uv` for installing dependencies in the CI job

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68598952f0548329808ebb6217523bbb