### PR TITLE
Implement metrics data model

### DIFF
--- a/app/metrics.py
+++ b/app/metrics.py
@@ -1,0 +1,53 @@
+"""Metrics data models and parsing utilities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import date
+from pathlib import Path
+import csv
+import json
+
+
+@dataclass
+class Metric:
+    """Representation of a single metric data point."""
+
+    name: str
+    date: date
+    value: float
+    metadata: dict[str, str] = field(default_factory=dict)
+
+
+def _parse_common(record: dict[str, str]) -> Metric:
+    """Parse common fields from a record dictionary."""
+    rec = record.copy()
+    name = rec.pop("name")
+    dt = date.fromisoformat(rec.pop("date"))
+    value = float(rec.pop("value"))
+    return Metric(name=name, date=dt, value=value, metadata=rec)
+
+
+def parse_json(path: Path) -> list[Metric]:
+    """Load metrics from a JSON file.
+
+    The file must contain a list of objects with at least ``name``, ``date`` and
+    ``value`` keys. Remaining keys are stored in :attr:`Metric.metadata`.
+    """
+    with path.open() as fh:
+        data = json.load(fh)
+    return [_parse_common(rec) for rec in data]
+
+
+def parse_csv(path: Path) -> list[Metric]:
+    """Load metrics from a CSV file.
+
+    The CSV must have headers including ``name``, ``date`` and ``value``. Any
+    additional columns are preserved in :attr:`Metric.metadata`.
+    """
+    metrics: list[Metric] = []
+    with path.open(newline="") as fh:
+        reader = csv.DictReader(fh)
+        for row in reader:
+            metrics.append(_parse_common(row))
+    return metrics

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,34 @@
+"""Tests for metrics data models and parsing utilities."""
+
+from datetime import date
+from pathlib import Path
+import json
+import csv
+
+from app.metrics import Metric, parse_json, parse_csv
+
+
+def test_parse_json(tmp_path: Path) -> None:
+    """Verify JSON parsing into Metric objects."""
+    data = [
+        {"name": "pull_request_count", "date": "2023-01-01", "value": 10, "repo": "example"}
+    ]
+    file = tmp_path / "metrics.json"
+    file.write_text(json.dumps(data))
+    metrics = parse_json(file)
+    assert metrics == [Metric(name="pull_request_count", date=date(2023, 1, 1), value=10.0, metadata={"repo": "example"})]
+
+
+def test_parse_csv(tmp_path: Path) -> None:
+    """Verify CSV parsing into Metric objects."""
+    rows = [
+        ["name", "date", "value", "repo"],
+        ["pull_request_count", "2023-01-01", "5", "example"],
+    ]
+    file = tmp_path / "metrics.csv"
+    with file.open("w", newline="") as fh:
+        writer = csv.writer(fh)
+        writer.writerows(rows)
+    metrics = parse_csv(file)
+    assert metrics == [Metric(name="pull_request_count", date=date(2023, 1, 1), value=5.0, metadata={"repo": "example"})]
+


### PR DESCRIPTION
## Summary
- add dataclass-based Metric model
- implement JSON and CSV parsing utilities
- test Metric parsing helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68598b2ae35083298a1c4197acba2726