### PR TITLE
Add custom Plotly theme

### DIFF
--- a/tests/test_theme.py
+++ b/tests/test_theme.py
@@ -1,0 +1,15 @@
+"""Tests for the custom Plotly theme."""
+
+from theme import codex_theme
+
+
+def test_theme_contains_expected_colors() -> None:
+    """Verify the theme colorway begins with the defined palette."""
+    tpl = codex_theme()
+    assert list(tpl.layout.colorway)[:3] == ["#2369BD", "#F25F5C", "#FFE066"]
+
+
+def test_theme_font_family() -> None:
+    """Ensure the theme specifies the Inter font family."""
+    tpl = codex_theme()
+    assert "Inter" in tpl.layout.font.family

--- a/theme.py
+++ b/theme.py
@@ -1,0 +1,34 @@
+"""Plotly theme configuration for the Codex Metrics dashboard."""
+
+from __future__ import annotations
+
+import plotly.graph_objects as go
+
+
+def codex_theme() -> go.layout.Template:
+    """Return the Plotly template for the dashboard.
+
+    The palette blends Bostock's vibrant hues with Tufte's minimalist
+    backgrounds. The modern ``Inter`` font offers readability and a
+    clean aesthetic.
+    """
+    colorway = [
+        "#2369BD",  # deep blue inspired by classic D3 examples
+        "#F25F5C",  # coral accent for highlights
+        "#FFE066",  # soft yellow for contrast
+        "#70C1B3",  # muted teal for variety
+        "#247BA0",  # darker blue for balance
+    ]
+
+    layout = go.Layout(
+        colorway=colorway,
+        font=dict(
+            family="Inter, Helvetica, sans-serif",
+            size=14,
+            color="#333333",
+        ),
+        paper_bgcolor="#ffffff",
+        plot_bgcolor="#f9f9f9",
+        title=dict(x=0.02, xanchor="left"),
+    )
+    return go.layout.Template(layout=layout)


### PR DESCRIPTION
## Summary
- design a Bostock/Tufte-inspired Plotly theme
- test theme color palette and fonts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68598c06cc2c8329ab9078f25b3a3a50