### PR TITLE
Add mypy to CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,8 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-          pip install pytest
+          pip install pytest mypy
       - name: Run tests
         run: pytest -q
+      - name: Run type checks
+        run: mypy app

--- a/README.md
+++ b/README.md
@@ -24,3 +24,12 @@ This project provides a Streamlit dashboard for visualizing code metrics.
    uv pip install -r requirements.txt
    ```
 
+## Type Checking
+
+Install `mypy` for static analysis and run it from the project root:
+
+```bash
+uv pip install mypy
+mypy app
+```
+

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,4 @@
+[mypy]
+python_version = 3.12
+files = app
+ignore_missing_imports = True


### PR DESCRIPTION
## Summary
- add `mypy` static analysis configuration
- run mypy in CI and update the README with type checking instructions

## Testing
- `pytest -q`
- `mypy app`


------
https://chatgpt.com/codex/tasks/task_e_68598cc67af88329b7e11fc12e6fe441