### PR TITLE
Implement active users loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,20 @@ This project provides a Streamlit dashboard for visualizing code metrics.
 
 ## Type Checking
 
-Install `mypy` for static analysis and run it from the project root:
+Install `mypy` for static analysis and run it from the project root. If any
+stub packages are missing, install them (e.g. `types-requests`).
 
 ```bash
 uv pip install mypy
+mypy app
+```
+
+## Development Workflow
+
+Always run the unit tests and type checks before committing code:
+
+```bash
+pytest -q
 mypy app
 ```
 

--- a/app/loaders.py
+++ b/app/loaders.py
@@ -53,7 +53,7 @@ def fetch_active_users(query: str = "codex", token: Optional[str] = None) -> lis
     if token:
         headers["Authorization"] = f"Bearer {token}"
 
-    params = {"q": query, "per_page": 100}
+    params: dict[str, int | str] = {"q": query, "per_page": 100}
     url = "https://api.github.com/search/commits"
 
     all_metrics: list[Metric] = []

--- a/app/loaders.py
+++ b/app/loaders.py
@@ -1,0 +1,72 @@
+"""Metric loaders for specialized GitHub data."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from datetime import date
+from pathlib import Path
+from typing import Any, Iterable, Optional
+import json
+import requests
+
+from .metrics import Metric
+
+
+def _aggregate_active_users(items: Iterable[dict[str, Any]]) -> list[Metric]:
+    """Aggregate unique contributors by repository and day."""
+    users_by_repo_day: dict[tuple[str, str], set[str]] = defaultdict(set)
+    for item in items:
+        repo = item["repository"]["full_name"]
+        user = item["author"]["login"]
+        dt = (
+            item.get("commit", {})
+            .get("author", {})
+            .get("date", item.get("created_at", ""))
+        )
+        day = dt.split("T", 1)[0]
+        if day:
+            users_by_repo_day[(repo, day)].add(user)
+
+    metrics = [
+        Metric(
+            name="active_users",
+            date=date.fromisoformat(day),
+            value=float(len(users)),
+            metadata={"repo": repo},
+        )
+        for (repo, day), users in sorted(users_by_repo_day.items())
+    ]
+    return metrics
+
+
+def load_active_users(path: Path) -> list[Metric]:
+    """Aggregate unique contributors per repo and day from GitHub search results."""
+    with path.open() as fh:
+        data = json.load(fh)
+
+    return _aggregate_active_users(data.get("items", []))
+
+
+def fetch_active_users(query: str = "codex", token: Optional[str] = None) -> list[Metric]:
+    """Search GitHub commits across all repositories and aggregate contributors."""
+    headers = {"Accept": "application/vnd.github+json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    params = {"q": query, "per_page": 100}
+    url = "https://api.github.com/search/commits"
+
+    all_metrics: list[Metric] = []
+    page = 1
+    while True:
+        resp = requests.get(url, headers=headers, params={**params, "page": page})
+        if resp.status_code == 422:  # invalid query or no results
+            break
+        resp.raise_for_status()
+        data = resp.json()
+        all_metrics.extend(_aggregate_active_users(data.get("items", [])))
+        if "next" not in resp.links:
+            break
+        page += 1
+
+    return all_metrics

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 streamlit==1.46.0
 plotly==6.1.2
 requests==2.32.3
+types-requests==2.32.4.20250611

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 streamlit==1.46.0
 plotly==6.1.2
+requests==2.32.3

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -5,7 +5,10 @@ from pathlib import Path
 import json
 import csv
 
+from typing import Any
 from app.metrics import Metric, parse_json, parse_csv
+from app.loaders import load_active_users, fetch_active_users
+import requests
 
 
 def test_parse_json(tmp_path: Path) -> None:
@@ -31,4 +34,81 @@ def test_parse_csv(tmp_path: Path) -> None:
         writer.writerows(rows)
     metrics = parse_csv(file)
     assert metrics == [Metric(name="pull_request_count", date=date(2023, 1, 1), value=5.0, metadata={"repo": "example"})]
+
+
+def test_load_active_users(tmp_path: Path) -> None:
+    """Aggregate unique authors per repo and date from search results."""
+    data = {
+        "items": [
+            {
+                "repository": {"full_name": "repo1"},
+                "author": {"login": "alice"},
+                "commit": {"author": {"date": "2023-01-01T12:00:00Z"}},
+            },
+            {
+                "repository": {"full_name": "repo1"},
+                "author": {"login": "bob"},
+                "commit": {"author": {"date": "2023-01-01T13:00:00Z"}},
+            },
+            {
+                "repository": {"full_name": "repo1"},
+                "author": {"login": "bob"},
+                "commit": {"author": {"date": "2023-01-02T10:00:00Z"}},
+            },
+            {
+                "repository": {"full_name": "repo2"},
+                "author": {"login": "alice"},
+                "commit": {"author": {"date": "2023-01-01T14:00:00Z"}},
+            },
+        ]
+    }
+    file = tmp_path / "search.json"
+    file.write_text(json.dumps(data))
+    metrics = load_active_users(file)
+    metrics = sorted(metrics, key=lambda m: (m.metadata["repo"], m.date))
+    assert metrics == [
+        Metric(name="active_users", date=date(2023, 1, 1), value=2.0, metadata={"repo": "repo1"}),
+        Metric(name="active_users", date=date(2023, 1, 2), value=1.0, metadata={"repo": "repo1"}),
+        Metric(name="active_users", date=date(2023, 1, 1), value=1.0, metadata={"repo": "repo2"}),
+    ]
+
+
+def test_fetch_active_users(monkeypatch) -> None:
+    """Fetch search results via GitHub API and aggregate metrics."""
+
+    pages = [
+        {
+            "items": [
+                {
+                    "repository": {"full_name": "repo1"},
+                    "author": {"login": "alice"},
+                    "commit": {"author": {"date": "2023-01-01T12:00:00Z"}},
+                },
+            ]
+        },
+        {"items": []},
+    ]
+
+    def fake_get(url: str, headers: dict[str, str] | None = None, params: dict[str, Any] | None = None):
+        page = int(params.get("page", 1)) - 1
+        data = pages[page]
+
+        class Resp:
+            status_code = 200
+            def __init__(self, data):
+                self._data = data
+                self.links = {} if page == len(pages) - 1 else {"next": {"url": "x"}}
+            def json(self) -> Any:
+                return self._data
+            def raise_for_status(self) -> None:
+                pass
+
+        return Resp(data)
+
+    monkeypatch.setattr(requests, "get", fake_get)
+
+    metrics = fetch_active_users(query="codex")
+    assert metrics == [
+        Metric(name="active_users", date=date(2023, 1, 1), value=1.0, metadata={"repo": "repo1"})
+    ]
 


### PR DESCRIPTION
## Summary
- add GitHub search result loader in `loaders.py`
- exercise loader with sample JSON in tests
- fetch active user stats from GitHub

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685990134ba48329a84072b0aa87b0b6