### PR TITLE
Add active users chart

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,12 +1,46 @@
 """Streamlit app entry point."""
 
 import streamlit as st
+import os
+from collections import defaultdict
+import plotly.graph_objects as go
+
+from .loaders import fetch_active_users
+from .metrics import Metric
+from theme import codex_theme
+
+
+def _build_active_users_chart(metrics: list[Metric]) -> go.Figure:
+    """Create an active users line chart grouped by repository."""
+    by_repo: dict[str, list[tuple[str, float]]] = defaultdict(list)
+    for m in metrics:
+        repo = m.metadata.get("repo", "")
+        by_repo[repo].append((m.date.isoformat(), m.value))
+
+    fig = go.Figure()
+    for repo, entries in by_repo.items():
+        entries.sort(key=lambda e: e[0])
+        fig.add_trace(
+            go.Scatter(x=[d for d, _ in entries], y=[v for _, v in entries], mode="lines+markers", name=repo)
+        )
+
+    fig.update_layout(template=codex_theme(), title="Active Users by Repository")
+    fig.update_xaxes(title="Date")
+    fig.update_yaxes(title="Users")
+    return fig
 
 
 def main() -> None:
     """Run the metrics dashboard app."""
     st.title("Metrics Dashboard")
-    st.write("Placeholder")
+
+    token = os.getenv("GITHUB_TOKEN")
+    metrics = fetch_active_users(query="codex", token=token)
+    if metrics:
+        fig = _build_active_users_chart(metrics)
+        st.plotly_chart(fig, use_container_width=True)
+    else:
+        st.write("No data available")
 
 
 if __name__ == "__main__":

--- a/data/active_users.json
+++ b/data/active_users.json
@@ -1,0 +1,8 @@
+{
+  "items": [
+    {"repository": {"full_name": "repo1"}, "author": {"login": "alice"}, "commit": {"author": {"date": "2023-01-01T12:00:00Z"}}},
+    {"repository": {"full_name": "repo1"}, "author": {"login": "bob"}, "commit": {"author": {"date": "2023-01-01T13:00:00Z"}}},
+    {"repository": {"full_name": "repo2"}, "author": {"login": "carol"}, "commit": {"author": {"date": "2023-01-01T14:00:00Z"}}}
+  ]
+}
+

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -4,11 +4,14 @@ from importlib import import_module, reload
 from types import ModuleType
 from pathlib import Path
 import sys
+from datetime import date
 
 # Ensure repository root is in sys.path when tests are executed from the tests directory.
 ROOT_DIR = Path(__file__).resolve().parents[1]
 if str(ROOT_DIR) not in sys.path:
     sys.path.insert(0, str(ROOT_DIR))
+
+from app.metrics import Metric
 
 
 class DummyStreamlit(ModuleType):
@@ -18,6 +21,7 @@ class DummyStreamlit(ModuleType):
         super().__init__("streamlit")
         self.titles: list[str] = []
         self.writes: list[str] = []
+        self.charts: list[object] = []
 
     def title(self, text: str) -> None:
         self.titles.append(text)
@@ -25,12 +29,21 @@ class DummyStreamlit(ModuleType):
     def write(self, text: str) -> None:
         self.writes.append(text)
 
+    def plotly_chart(self, fig, use_container_width: bool = False) -> None:
+        self.charts.append(fig)
+
 
 def test_main_displays_title(monkeypatch) -> None:
     """Ensure the app displays the placeholder title."""
     dummy = DummyStreamlit()
     monkeypatch.setitem(sys.modules, "streamlit", dummy)
     app_main = reload(import_module("app.main"))
+
+    def fake_fetch_active_users(*_, **__):
+        return [Metric(name="active_users", date=date(2023, 1, 1), value=1.0, metadata={"repo": "repo1"})]
+
+    monkeypatch.setattr(app_main, "fetch_active_users", fake_fetch_active_users)
     app_main.main()
     assert dummy.titles == ["Metrics Dashboard"]
+    assert len(dummy.charts) == 1
 


### PR DESCRIPTION
## Summary
- display active users data from GitHub using `fetch_active_users`
- patch tests to mock the GitHub call

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68599505c83083299b26298cca72cb42